### PR TITLE
Updating Jacoco version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.1] - TBD
+### Changed
+- Updated Jacoco version to 0.8.4 (was 0.8.2) for official Java 11 support.
+
 ## [1.0.0] - 2019-07-25
 ### Changed
-- Initial release
+- Initial release.

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
     <failsafe.maven.plugin.version>2.22.0</failsafe.maven.plugin.version>
     <eg.oss.plugin.config.version>1.0.0</eg.oss.plugin.config.version>
-    <jacoco.version>0.8.2</jacoco.version>
+    <jacoco.version>0.8.4</jacoco.version>
     <jdk.version>1.8</jdk.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>
     <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>


### PR DESCRIPTION
As per the Jacoco docs [here](https://www.jacoco.org/jacoco/trunk/doc/changes.html), version `0.8.4` supports Java 11 and even Java 12.