### PR TITLE
Explicitly add `maven-surefire-plugin` as a build plugin 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.0] - TBD
+### Added
+- Explicitly add `maven-surefire-plugin` as a build plugin for JUnit5 usage.
+
 ## [1.2.0] - 2020-01-10
 ### Added
 - Added [Spotless Maven Plugin](https://github.com/diffplug/spotless/tree/master/plugin-maven), version 1.27.0 with 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.3.0] - TBD
+## [1.3.0] - 2020-01-22
 ### Added
 - Explicitly add `maven-surefire-plugin` as a build plugin for JUnit5 usage.
 

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ base functionality and need to publish artifacts to [Maven Central](https://sear
 # Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
-Copyright 2019 Expedia, Inc.
+Copyright 2019-2020 Expedia, Inc.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.expediagroup</groupId>
   <artifactId>eg-oss-parent</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <description>Parent POM for Expedia Group open source projects</description>
   <packaging>pom</packaging>
   <url>https://github.com/ExpediaGroup/eg-oss-parent</url>
@@ -254,6 +254,11 @@
           <goals>deploy</goals>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven.surefire.plugin.version}</version>
+      </plugin>      
       <!-- used to determine the current year -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This is needed for certain ways of running JUnit5 in child projects.