### PR TITLE
egdl-1429: update plugins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: build
+on: [push, pull_request]
+jobs:
+  test:
+    name: Package and run all tests
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Run Maven Targets
+      run: mvn package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.1.0] - TBD
 ### Changed
-- Updated `plugin.config` from 0.0.2 to 0.0.3.
+- Updated `eg.oss.plugin.config` from 1.1.0 to 1.2.0.
 - Updated `failsafe.maven.plugin` from 2.22.0 from to 3.0.0-M5.
 - Updated `Jacoco` from 0.8.4 to 0.8.6.
 - Updated `checkstyle.plugin` from 3.0.0 to 3.1.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.0] - TBD
+### Changed
+- Updated `plugin.config` from 0.0.2 to 0.0.3.
+- Updated `failsafe.maven.plugin` from 2.22.0 from to 3.0.0-M5.
+- Updated `Jacoco` from 0.8.4 to 0.8.6.
+- Updated `checkstyle.plugin` from 3.0.0 to 3.1.1.
+- Updated `compiler.plugin` from 3.8.0 to 3.8.1.
+- Updated `dependency.plugin` from 3.1.1 to 3.1.2.
+- Updated `jar.plugin` from 3.1.0 to 3.2.0.
+- Updated `javadoc.plugin` from 3.0.1 to 3.2.0.
+- Updated `site.plugin` from 3.7.1 to 3.9.1.
+- Updated `source.plugin` from 3.0.1 to 3.2.0.
+- Updated `spotbugs.plugin` from 3.1.12.2 to 4.0.4.
+- Updated `surefire.plugin` from 2.22.0 to 3.0.0-M5.
+- Updated `release.plugin` from 2.5.3 to 3.0.0-M1.
+- Updated `spotless.maven.plugin` from 1.27.0 to 2.4.1.
+
+
 ## [2.0.0] - 2020-08-17
 ### Changed
 - renamed `travis` profile to `coveralls`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated `release.plugin` from 2.5.3 to 3.0.0-M1.
 - Updated `spotless.maven.plugin` from 1.27.0 to 2.4.1.
 
-
 ## [2.0.0] - 2020-08-17
 ### Changed
 - renamed `travis` profile to `coveralls`.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.expediagroup</groupId>
   <artifactId>eg-oss-parent</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <description>Parent POM for Expedia Group open source projects</description>
   <packaging>pom</packaging>
   <url>https://github.com/ExpediaGroup/eg-oss-parent</url>

--- a/pom.xml
+++ b/pom.xml
@@ -44,24 +44,24 @@
 
     <buildnumber.maven.plugin.version>1.4</buildnumber.maven.plugin.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
-    <eg.oss.plugin.config.version>1.1.0</eg.oss.plugin.config.version>
-    <failsafe.maven.plugin.version>2.22.0</failsafe.maven.plugin.version>
-    <jacoco.version>0.8.4</jacoco.version>
+    <eg.oss.plugin.config.version>1.2.0</eg.oss.plugin.config.version>
+    <failsafe.maven.plugin.version>3.0.0-M5</failsafe.maven.plugin.version>
+    <jacoco.version>0.8.6</jacoco.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>
     <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
-    <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
-    <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
-    <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
+    <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
+    <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+    <maven.dependency.plugin.version>3.1.2</maven.dependency.plugin.version>
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
-    <maven.jar.plugin.version>3.1.0</maven.jar.plugin.version>
-    <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
-    <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
-    <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
-    <maven.spotbugs.plugin.version>3.1.12.2</maven.spotbugs.plugin.version>
-    <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
-    <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+    <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
+    <maven.javadoc.plugin.version>3.2.0</maven.javadoc.plugin.version>
+    <maven.site.plugin.version>3.9.1</maven.site.plugin.version>
+    <maven.source.plugin.version>3.2.0</maven.source.plugin.version>
+    <maven.spotbugs.plugin.version>4.0.4</maven.spotbugs.plugin.version>
+    <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
+    <maven.release.plugin.version>3.0.0-M1</maven.release.plugin.version>
     <nexus.staging.maven.plugin.version>1.6.8</nexus.staging.maven.plugin.version>
-    <spotless.maven.plugin.version>1.27.0</spotless.maven.plugin.version>
+    <spotless.maven.plugin.version>2.4.1</spotless.maven.plugin.version>
 
     <!-- EG specific plugin properties -->
     <checkstyle.config>${project.build.directory}/plugin-config/checkstyle/eg-checkstyle.xml</checkstyle.config>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <buildnumber.maven.plugin.version>1.4</buildnumber.maven.plugin.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
-    <eg.oss.plugin.config.version>1.2.0</eg.oss.plugin.config.version>
+    <eg.oss.plugin.config.version>1.2.0-SNAPSHOT</eg.oss.plugin.config.version>
     <failsafe.maven.plugin.version>3.0.0-M5</failsafe.maven.plugin.version>
     <jacoco.version>0.8.6</jacoco.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <buildnumber.maven.plugin.version>1.4</buildnumber.maven.plugin.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>
-    <eg.oss.plugin.config.version>1.2.0-SNAPSHOT</eg.oss.plugin.config.version>
+    <eg.oss.plugin.config.version>1.2.0</eg.oss.plugin.config.version>
     <failsafe.maven.plugin.version>3.0.0-M5</failsafe.maven.plugin.version>
     <jacoco.version>0.8.6</jacoco.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>


### PR DESCRIPTION
I **updated the plugin versions**. This PR https://github.com/ExpediaGroup/eg-oss-plugin-config/pull/5 needs to be merged first so that eg-oss-parent can use the version 1.2.0 of eg-oss-plugin-config.