### PR TITLE
Added "javadoc.source.version" for Java 11 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0] - TBD
+### Added
+- A `javadoc.source.version` property (set to `8` by default).
+
 ## [2.1.0] - 2020-09-24
 ### Changed
 - Updated `eg.oss.plugin.config` from 1.1.0 to 1.2.0.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.expediagroup</groupId>
   <artifactId>eg-oss-parent</artifactId>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <description>Parent POM for Expedia Group open source projects</description>
   <packaging>pom</packaging>
   <url>https://github.com/ExpediaGroup/eg-oss-parent</url>
@@ -47,6 +47,7 @@
     <eg.oss.plugin.config.version>1.2.0</eg.oss.plugin.config.version>
     <failsafe.maven.plugin.version>3.0.0-M5</failsafe.maven.plugin.version>
     <jacoco.version>0.8.6</jacoco.version>
+    <javadoc.source.version>8</javadoc.source.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>
     <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
     <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
@@ -226,6 +227,7 @@
         <version>${maven.javadoc.plugin.version}</version>
         <configuration>
           <encoding>${project.build.sourceEncoding}</encoding>
+          <source>${javadoc.source.version}</source>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
This is essentially the same change as https://github.com/HotelsDotCom/hotels-oss-parent/pull/37/files and is required to prevent some javadoc errors when building on Java 11.