### PR TITLE
Spotless import order property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.1] - 2021-07-26
+### Added
+- Added a new maven property: `spotless.config.import.order.def` that specifies the import order to be used from the `maven-spotless-plugin`.
+
 ## [2.4.0] - 2021-07-23
 ### Added
 - Added the `sonatype-oss-release-github-actions` profile to enable releases from Github Actions. This profile breaks the releases in Jenkins so `sonatype-oss-release` is still there for backwards compatibility, but it will become deprecated, so we encourage users to use `sonatype-oss-release-github-actions` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.4.1] - 2021-07-26
 ### Added
-- Added a new maven property: `spotless.config.import.order.def` that specifies the import order to be used from the `maven-spotless-plugin`.
+- Added two new properties related to the `maven-spotless-plugin`
+  * `spotless.config.import.order.def`: it specifies the import order to be applied.
+  * `spotless.config.execution.skip`: if set to true the spotless execution is skipped
 
 ## [2.4.0] - 2021-07-23
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <mycila.config.header>${project.build.directory}/plugin-config/mycila/APACHE-2.txt</mycila.config.header>
     <mycila.config.header.def>${project.build.directory}/plugin-config/mycila/eg-definitions.xml</mycila.config.header.def>
     <spotbugs.config>${project.build.directory}/plugin-config/spotbugs/eg-spotbugs-exclude.xml</spotbugs.config>
+    <spotless.config.import.order.def>\#java,\#javax,\#org,\#,\#com,\#com.expedia,\#com.expediagroup,\#com.hotels,java,javax,org,,com,com.expedia,com.expediagroup,com.hotels</spotless.config.import.order.def>
   </properties>
 
   <distributionManagement>
@@ -115,7 +116,7 @@
           <java>
             <removeUnusedImports />
             <importOrder>
-              <order>\#java,\#javax,\#org,\#,\#com,\#com.expedia,\#com.expediagroup,\#com.hotels,java,javax,org,,com,com.expedia,com.expediagroup,com.hotels</order>
+              <order>${spotless.config.import.order.def}</order>
             </importOrder>
           </java>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <mycila.config.header.def>${project.build.directory}/plugin-config/mycila/eg-definitions.xml</mycila.config.header.def>
     <spotbugs.config>${project.build.directory}/plugin-config/spotbugs/eg-spotbugs-exclude.xml</spotbugs.config>
     <spotless.config.import.order.def>\#java,\#javax,\#org,\#,\#com,\#com.expedia,\#com.expediagroup,\#com.hotels,java,javax,org,,com,com.expedia,com.expediagroup,com.hotels</spotless.config.import.order.def>
+    <spotless.config.execution.skip>false</spotless.config.execution.skip>
   </properties>
 
   <distributionManagement>
@@ -119,6 +120,7 @@
               <order>${spotless.config.import.order.def}</order>
             </importOrder>
           </java>
+          <skip>${spotless.config.execution.skip}</skip>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Defines two additional maven properties related to the `maven-spotless-plugin`:

1. `spotless.config.import.order.def`: it specifies the import order to be applied. This allows the project using this parent pom to override it if needed without declaring again the entire maven plugin.
2. `spotless.config.execution.skip`: if set to true the spotless execution is skipped
